### PR TITLE
Add stress test

### DIFF
--- a/benchmark-llm-api-with-dataset.py
+++ b/benchmark-llm-api-with-dataset.py
@@ -1,0 +1,233 @@
+import argparse
+import json
+import os
+import time
+from openai import OpenAI
+
+def main():
+    # Set up argument parser
+    parser = argparse.ArgumentParser(description="Send requests to an OpenAI-compatible endpoint.")
+    parser.add_argument("--api-key", required=True, help="OpenAI API key.")
+    parser.add_argument("--base-url", required=True, help="OpenAI base URL (proxy endpoint).")
+    parser.add_argument("--input-file", required=True, help="Path to the input .jsonl file.")
+    parser.add_argument("--model", default="Qwen/Qwen3-235B-A22B-Instruct-2507-FP8", help="The model to use for chat completions.")
+    parser.add_argument("--max-tokens", type=int, default=1000, help="The maximum number of tokens to generate.")
+    parser.add_argument("--long-response", action="store_true", help="Request extremely detailed and verbose responses from the model.")
+    
+    args = parser.parse_args()
+
+    # Generate the output filename
+    base_name = os.path.splitext(args.input_file)[0]
+    suffix = "_long_response" if args.long_response else ""
+    output_file = f"{base_name}{suffix}_output_data.jsonl"
+
+    # Initialize the OpenAI client with arguments
+    client = OpenAI(
+        api_key=args.api_key,
+        base_url=args.base_url,
+    )
+
+    process_jsonl_file(client, args.input_file, output_file, args.model, args.max_tokens, args.long_response)
+
+def process_jsonl_file(client, input_file, output_file, model, max_tokens, long_response):
+    """
+    Reads an input .jsonl file, sends each line's content to the OpenAI chat completion endpoint,
+    and writes the response to an output .jsonl file.
+    """
+    durations = []
+    request_count = 0
+    total_prompt_tokens = 0
+    total_completion_tokens = 0
+    total_cached_tokens = 0
+    total_tokens_list = []
+    prompt_tokens_list = []
+    completion_tokens_list = []
+    tps_list = []
+    
+    try:
+        with open(input_file, 'r') as f_in, open(output_file, 'w') as f_out:
+            for line in f_in:
+                try:
+                    # Parse the JSON object from the line
+                    payload = json.loads(line.strip())
+                    messages = payload.get("messages")
+
+                    if not messages:
+                        print("Skipping line: 'messages' key not found.")
+                        continue
+
+                    # If long_response flag is set, modify the last user message
+                    if long_response:
+                        # Find the last user message and append the verbose request
+                        for i in range(len(messages) - 1, -1, -1):
+                            if messages[i].get("role") == "user":
+                                original_content = messages[i].get("content", "")
+                                messages[i]["content"] = original_content + "\n\nPlease provide an extremely detailed, verbose, and comprehensive response. Ensure the answer is as long and thorough as possible, exploring all facets of the topic in depth."
+                                break
+
+                    # Record start time for e2e duration
+                    start_time = time.time()
+
+                    # Send the request to the chat completions endpoint
+                    chat_completion = client.chat.completions.create(
+                        messages=messages,
+                        model=model,
+                        max_tokens=max_tokens,
+                    )
+
+                    # Record end time and calculate duration
+                    end_time = time.time()
+                    duration = end_time - start_time
+                    durations.append(duration)
+                    request_count += 1
+
+                    # Extract the last user message as the question
+                    question = ""
+                    for msg in reversed(messages):
+                        if msg.get("role") == "user":
+                            question = msg.get("content", "")
+                            break
+                    
+                    # Extract the assistant's response as the answer
+                    answer = chat_completion.choices[0].message.content
+
+                    # Extract token usage information
+                    usage = chat_completion.usage
+                    prompt_tokens = usage.prompt_tokens if usage else 0
+                    completion_tokens = usage.completion_tokens if usage else 0
+                    total_tokens = usage.total_tokens if usage else 0
+                    
+                    # Check for cached tokens (some APIs provide this)
+                    cached_tokens = getattr(usage, 'cached_tokens', 0) if usage else 0
+
+                    # Accumulate statistics
+                    total_prompt_tokens += prompt_tokens
+                    total_completion_tokens += completion_tokens
+                    total_cached_tokens += cached_tokens
+                    total_tokens_list.append(total_tokens)
+                    prompt_tokens_list.append(prompt_tokens)
+                    completion_tokens_list.append(completion_tokens)
+                    
+                    # Calculate TPS
+                    tps = completion_tokens / duration if duration > 0 else 0
+                    tps_list.append(tps)
+
+                    # Create simplified output format with token usage
+                    output_data = {
+                        "question": question,
+                        "answer": answer,
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                        "cached_tokens": cached_tokens,
+                        "total_tokens": total_tokens,
+                        "e2e_duration": round(duration, 2),
+                        "tps": round(tps, 2)
+                    }
+
+                    # Write the simplified response to the output file
+                    f_out.write(json.dumps(output_data) + '\n')
+                    print(f"Request {request_count}: E2E duration: {duration:.2f}s | Tokens - Input: {prompt_tokens}, Cached: {cached_tokens}, Completion: {completion_tokens}, Total: {total_tokens}")
+
+                except json.JSONDecodeError:
+                    print(f"Skipping invalid JSON line: {line.strip()}")
+                except Exception as e:
+                    print(f"An error occurred: {e}")
+    except FileNotFoundError:
+        print(f"Error: The file '{input_file}' was not found.")
+    
+    # Generate final report
+    if durations and total_tokens_list:
+        # Calculate percentiles
+        def calculate_percentile(data, percentile):
+            sorted_data = sorted(data)
+            index = int(len(sorted_data) * percentile / 100)
+            if index >= len(sorted_data):
+                index = len(sorted_data) - 1
+            return sorted_data[index]
+        
+        # Duration statistics
+        avg_duration = sum(durations) / len(durations)
+        min_duration = min(durations)
+        max_duration = max(durations)
+        p50_duration = calculate_percentile(durations, 50)
+        p90_duration = calculate_percentile(durations, 90)
+        
+        # Token statistics
+        avg_total_tokens = sum(total_tokens_list) / len(total_tokens_list)
+        p50_total_tokens = calculate_percentile(total_tokens_list, 50)
+        p90_total_tokens = calculate_percentile(total_tokens_list, 90)
+        
+        avg_prompt_tokens = sum(prompt_tokens_list) / len(prompt_tokens_list)
+        avg_completion_tokens = sum(completion_tokens_list) / len(completion_tokens_list)
+        
+        # TPS statistics
+        avg_tps = sum(tps_list) / len(tps_list)
+        min_tps = min(tps_list)
+        max_tps = max(tps_list)
+        p50_tps = calculate_percentile(tps_list, 50)
+        p90_tps = calculate_percentile(tps_list, 90)
+        
+        # Create comprehensive report
+        report = {
+            "summary": {
+                "total_requests_processed": request_count,
+                "total_prompt_tokens": total_prompt_tokens,
+                "total_completion_tokens": total_completion_tokens,
+                "total_cached_tokens": total_cached_tokens,
+                "total_tokens_consumed": total_prompt_tokens + total_completion_tokens
+            },
+            "duration_stats": {
+                "avg_e2e_duration_seconds": round(avg_duration, 2),
+                "min_e2e_duration_seconds": round(min_duration, 2),
+                "max_e2e_duration_seconds": round(max_duration, 2),
+                "p50_e2e_duration_seconds": round(p50_duration, 2),
+                "p90_e2e_duration_seconds": round(p90_duration, 2)
+            },
+            "token_stats": {
+                "avg_total_tokens_per_request": round(avg_total_tokens, 2),
+                "avg_prompt_tokens_per_request": round(avg_prompt_tokens, 2),
+                "avg_completion_tokens_per_request": round(avg_completion_tokens, 2),
+                "p50_total_tokens_per_request": p50_total_tokens,
+                "p90_total_tokens_per_request": p90_total_tokens
+            },
+            "tps_stats": {
+                "avg_tps": round(avg_tps, 2),
+                "min_tps": round(min_tps, 2),
+                "max_tps": round(max_tps, 2),
+                "p50_tps": round(p50_tps, 2),
+                "p90_tps": round(p90_tps, 2)
+            },
+            "model_info": {
+                "model": model,
+                "max_tokens_limit": max_tokens
+            }
+        }
+        
+        # Save report to JSON file
+        base_name = os.path.splitext(input_file)[0]
+        suffix = "_long_response" if long_response else ""
+        report_file = f"{base_name}{suffix}_final_report.json"
+        
+        with open(report_file, 'w') as f:
+            json.dump(report, f, indent=2)
+        
+        # Print summary to console
+        print(f"\n=== Performance Summary ===")
+        print(f"Total requests processed: {request_count}")
+        print(f"Average E2E duration: {avg_duration:.2f}s")
+        print(f"P50 E2E duration: {p50_duration:.2f}s")
+        print(f"P90 E2E duration: {p90_duration:.2f}s")
+        print(f"Total tokens consumed: {total_prompt_tokens + total_completion_tokens:,}")
+        print(f"Total cached tokens: {total_cached_tokens:,}")
+        print(f"Average tokens per request: {avg_total_tokens:.1f}")
+        print(f"P50 tokens per request: {p50_total_tokens}")
+        print(f"P90 tokens per request: {p90_total_tokens}")
+        print(f"Average TPS: {avg_tps:.2f}")
+        print(f"P50 TPS: {p50_tps:.2f}")
+        print(f"P90 TPS: {p90_tps:.2f}")
+        print(f"\nDetailed report saved to: {report_file}")
+    else:
+        print("No requests were processed successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/src/smoke/aggregate_benchmark_logs.py
+++ b/src/smoke/aggregate_benchmark_logs.py
@@ -1,0 +1,128 @@
+import argparse
+import os
+import pandas as pd
+import numpy as np
+import yaml
+
+def calculate_statistics(series):
+    """Calculates mean, stdev, percentiles, and a simple distribution for a pandas Series."""
+    if series.empty or series.isnull().all():
+        return {
+            'mean': None, 'stdev': None, 'p05': None, 'p50': None,
+            'p80': None, 'p95': None, 'p99': None, 'p999': None,
+            'distribution': None
+        }
+    
+    # Simplified histogram representation
+    hist, _ = np.histogram(series, bins=5)
+    distribution_str = "|".join(map(str, hist))
+    
+    return {
+        'mean': series.mean(),
+        'stdev': series.std(),
+        'p05': series.quantile(0.05),
+        'p50': series.quantile(0.50),
+        'p80': series.quantile(0.80),
+        'p95': series.quantile(0.95),
+        'p99': series.quantile(0.99),
+        'p999': series.quantile(0.999),
+        'distribution': distribution_str
+    }
+
+def main():
+    parser = argparse.ArgumentParser(description="Aggregate benchmark logs into a final report.")
+    parser.add_argument("--run-directory", required=True, help="The timestamped directory containing the raw benchmark CSVs.")
+    parser.add_argument("--test-config", default="stress-test.yaml", help="Path to the stress-test.yaml file to get the metrics list.")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.run_directory):
+        raise FileNotFoundError(f"Run directory not found: {args.run_directory}")
+
+    with open(args.test_config, 'r') as f:
+        config = yaml.safe_load(f)
+    
+    final_report_columns = config['test_config'].get('aggregation_metrics', [])
+    if not final_report_columns:
+        raise ValueError("'aggregation_metrics' not found in test_config. Cannot generate report.")
+
+    # Find all raw CSV files in the directory
+    csv_files = [f for f in os.listdir(args.run_directory) if f.startswith('raw_results_') and f.endswith('.csv')]
+    if not csv_files:
+        print(f"No raw result CSVs found in {args.run_directory}. Nothing to aggregate.")
+        return
+
+    # Load all data into a single DataFrame
+    df_list = [pd.read_csv(os.path.join(args.run_directory, f)) for f in csv_files]
+    full_df = pd.concat(df_list, ignore_index=True)
+
+    # Group by traffic level to aggregate results
+    grouped = full_df.groupby('traffic_level')
+    
+    aggregated_data = []
+
+    for level, group in grouped:
+        successful_requests = group[group['success'] == True]
+        
+        row = {
+            'provider_name': group['provider_name'].iloc[0],
+            'provider_model': group['provider_model'].iloc[0],
+            'traffic_mode': group['test_mode'].iloc[0],
+            'traffic_level': level,
+            'dataset_name': group['dataset_name'].iloc[0], # Assumes same dataset for the run
+        }
+
+        # Input/Output Token Stats
+        row['input_total_tokens'] = successful_requests['input_tokens'].sum()
+        row['output_total_tokens'] = successful_requests['output_tokens'].sum()
+        row['input_avg_len'] = successful_requests['input_tokens'].mean()
+        row['input_stdev_len'] = successful_requests['input_tokens'].std()
+        row['input_min_len'] = successful_requests['input_tokens'].min()
+        row['input_max_len'] = successful_requests['input_tokens'].max()
+        row['output_avg_len'] = successful_requests['output_tokens'].mean()
+        row['output_stdev_len'] = successful_requests['output_tokens'].std()
+        row['output_min_len'] = successful_requests['output_tokens'].min()
+        row['output_max_len'] = successful_requests['output_tokens'].max()
+
+        # TTFT, User TPS, E2E Duration Stats
+        for metric in ['ttft', 'user_tps', 'e2e_duration']:
+            stats = calculate_statistics(successful_requests[metric])
+            # Rename e2e_duration to e2e for the report
+            report_metric_name = 'e2e' if metric == 'e2e_duration' else metric
+            for stat_name, value in stats.items():
+                row[f'{report_metric_name}_{stat_name}'] = value
+
+        # Summary Stats
+        total_requests = len(group)
+        failed_requests = total_requests - len(successful_requests)
+        total_duration = successful_requests['e2e_duration'].sum()
+
+        row['summary_total_num_requests'] = total_requests
+        row['summary_num_failed_requests'] = failed_requests
+        row['acceptance_rate'] = (len(successful_requests) / total_requests) if total_requests > 0 else 0
+        row['summary_total_elapsed_time_s'] = total_duration
+        
+        # Note: This is a simplified QPS. A more accurate measure would use the test's wall-clock time.
+        row['summary_actual_qps'] = len(successful_requests) / config['test_config']['stress_duration_seconds']
+        row['summary_job_level_tps'] = row['output_total_tokens'] / total_duration if total_duration > 0 else 0
+
+        aggregated_data.append(row)
+
+    # Create the final DataFrame and save to CSV
+    report_df = pd.DataFrame(aggregated_data)
+    
+    # Ensure all required columns are present, filling missing ones with None
+    for col in final_report_columns:
+        if col not in report_df.columns:
+            report_df[col] = None
+    
+    # Order columns as specified in the config
+    report_df = report_df[final_report_columns]
+
+    output_path = os.path.join(args.run_directory, "aggregated_report.csv")
+    report_df.to_csv(output_path, index=False)
+
+    print(f"\n--- Aggregation complete. ---")
+    print(f"Final report saved to: {output_path}")
+
+if __name__ == "__main__":
+    main()

--- a/src/smoke/stress-test.yaml
+++ b/src/smoke/stress-test.yaml
@@ -1,0 +1,110 @@
+# stress-test.yaml
+
+# Section 1: Defines the test execution parameters.
+test_config:
+  test_mode: "stress"
+  concurrency_levels: [1, 2, 4, 8, 16, 32]
+  qps_levels: [1, 2, 3, 4, 5] # Included for future QPS mode
+  stress_duration_seconds: 10
+
+  # Defines the raw, per-request metrics to be collected.
+  per_request_metrics:
+    - request_id
+    - provider_name
+    - provider_model
+    - test_mode
+    - traffic_level
+    - dataset_name
+    - dataset_type
+    - ttft
+    - e2e_duration
+    - user_tps
+    - input_tokens
+    - output_tokens
+    - cached_tokens
+    - success
+    - error_message
+
+  # Defines the columns and order for the final aggregated report.
+  aggregation_metrics:
+    - provider_name
+    - provider_model
+    - traffic_mode
+    - traffic_level
+    - input_avg_len
+    - input_stdev_len
+    - input_min_len
+    - input_max_len
+    - input_total_tokens
+    - output_avg_len
+    - output_stdev_len
+    - output_min_len
+    - output_max_len
+    - output_total_tokens
+    - ttft_mean
+    - ttft_stdev
+    - ttft_p05
+    - ttft_p50
+    - ttft_p80
+    - ttft_p95
+    - ttft_p99
+    - ttft_p999
+    - ttft_distribution
+    - user_tps_mean
+    - user_tps_stdev
+    - user_tps_p05
+    - user_tps_p50
+    - user_tps_p80
+    - user_tps_p95
+    - user_tps_p99
+    - user_tps_p999
+    - user_tps_distribution
+    - e2e_mean
+    - e2e_stdev
+    - e2e_p05
+    - e2e_p50
+    - e2e_p80
+    - e2e_p95
+    - e2e_p99
+    - e2e_p999
+    - e2e_distribution
+    - summary_total_num_requests
+    - summary_total_elapsed_time_s
+    - summary_job_level_tps
+    - summary_actual_qps
+    - summary_num_failed_requests
+    - per_gpu_num_gpus
+    - per_gpu_tps_mean
+    - per_gpu_tps_stdev
+    - acceptance_rate
+    - hf_dataset_name
+
+# Section 2: Defines vendors to override or add to the base config.
+vendors:
+  vertexai:
+    api_base: "https://us-central1-aiplatform.googleapis.com/v1/projects/your-project-id/locations/us-central1/endpoints/your-endpoint-id"
+    api_key_env: "VERTEX_API_KEY"
+    model_config:
+      Qwen/Qwen1.5-7B-Chat-AWQ:
+        max_tokens: 1000
+
+# Section 3: Defines the test scenarios or "features".
+features:
+  chatbot:
+    note: "A general-purpose chatbot test."
+    datasets:
+      - "short_qa_v1"
+      - "goldenfox_5000_tokens"
+      - "goldenfox_2000_tokens"
+
+# Section 4: A library of all available datasets.
+datasets:
+  goldenfox_5000_tokens:
+    note: "A dataset of 500 prompts with a minimum of 5000 tokens."
+    path: "src/smoke/data/generated_goldenfox_dataset_500_min_5000tokens.jsonl"
+    type: "custom_messages_jsonl"
+
+  goldenfox_2000_tokens:
+    note: "A dataset of 500 prompts with a minimum of 2000 tokens."
+    path: "src/smoke/data/generated_goldenfox_dataset_500_min_2000tokens.jsonl"
+    type: "custom_messages_jsonl"

--- a/src/smoke/stress_test.py
+++ b/src/smoke/stress_test.py
@@ -1,0 +1,263 @@
+import argparse
+import asyncio
+import os
+import yaml
+import json
+import csv
+import time
+import uuid
+from datetime import datetime
+from openai import AsyncOpenAI
+from tqdm import tqdm
+
+async def load_prompts(datasets_config, feature_datasets):
+    """
+    Asynchronously generates prompts from a list of dataset files.
+    """
+    total_prompts = 0
+    # First, count the prompts
+    for dataset_name in feature_datasets:
+        dataset_info = datasets_config.get(dataset_name)
+        if not dataset_info:
+            raise ValueError(f"Dataset '{dataset_name}' not found in datasets configuration.")
+        
+        file_path = dataset_info['path']
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"Dataset file not found: {file_path}")
+
+        with open(file_path, 'r') as f:
+            for _ in f:
+                total_prompts += 1
+    
+    print(f"INFO: Found a total of {total_prompts} prompts across {len(feature_datasets)} dataset(s).")
+
+    # Now, yield the prompts
+    for dataset_name in feature_datasets:
+        dataset_info = datasets_config[dataset_name]
+        file_path = dataset_info['path']
+        dataset_type = dataset_info['type']
+
+        if dataset_type == "custom_messages_jsonl":
+            with open(file_path, 'r') as f:
+                for line in f:
+                    try:
+                        payload = json.loads(line)
+                        if "messages" in payload:
+                            yield {"payload": payload, "dataset_name": dataset_name, "dataset_type": dataset_type}
+                    except json.JSONDecodeError:
+                        print(f"WARNING: Skipping invalid JSON line in {file_path}")
+                        continue
+        else:
+            print(f"WARNING: Skipping unsupported dataset type '{dataset_type}' for dataset '{dataset_name}'")
+
+
+async def worker(worker_id, client, prompt_generator, results_queue, semaphore, config, run_config):
+    """
+    A worker that sends requests to the API endpoint as fast as possible.
+    """
+    while True:
+        try:
+            prompt_data = await anext(prompt_generator)
+        except StopAsyncIteration:
+            break # No more prompts
+
+        async with semaphore:
+            request_id = str(uuid.uuid4())
+            start_time = time.monotonic()
+            first_token_time = None
+            
+            try:
+                stream = await client.chat.completions.create(
+                    model=run_config['model_name'],
+                    messages=prompt_data['payload']['messages'],
+                    max_tokens=run_config['max_tokens'],
+                    stream=True
+                )
+                
+                output_tokens = -1
+                input_tokens = -1
+                cached_tokens = -1
+                last_chunk = None
+                async for chunk in stream:
+                    if first_token_time is None:
+                        first_token_time = time.monotonic()
+                    last_chunk = chunk
+
+                end_time = time.monotonic()
+
+                if last_chunk and hasattr(last_chunk, 'usage') and last_chunk.usage is not None:
+                    input_tokens = last_chunk.usage.prompt_tokens
+                    output_tokens = last_chunk.usage.completion_tokens
+                
+                result = {
+                    "request_id": request_id,
+                    "provider_name": run_config['vendor'],
+                    "provider_model": run_config['model'],
+                    "test_mode": run_config['mode'],
+                    "traffic_level": run_config['level'],
+                    "dataset_name": prompt_data['dataset_name'],
+                    "dataset_type": prompt_data['dataset_type'],
+                    "ttft": first_token_time - start_time if first_token_time else end_time - start_time,
+                    "e2e_duration": end_time - start_time,
+                    "user_tps": output_tokens / (end_time - start_time) if (end_time - start_time) > 0 and output_tokens != -1 else 0,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "cached_tokens": cached_tokens,
+                    "success": True,
+                    "error_message": ""
+                }
+
+            except Exception as e:
+                end_time = time.monotonic()
+                result = {
+                    "request_id": request_id,
+                    "provider_name": run_config['vendor'],
+                    "provider_model": run_config['model'],
+                    "test_mode": run_config['mode'],
+                    "traffic_level": run_config['level'],
+                    "dataset_name": prompt_data['dataset_name'],
+                    "dataset_type": prompt_data['dataset_type'],
+                    "ttft": None,
+                    "e2e_duration": end_time - start_time,
+                    "user_tps": None,
+                    "input_tokens": -1,
+                    "output_tokens": -1,
+                    "cached_tokens": -1,
+                    "success": False,
+                    "error_message": str(e)
+                }
+            
+            await results_queue.put(result)
+
+
+async def results_writer(results_queue, output_file, metrics):
+    """
+    Writes results from the queue to a CSV file.
+    """
+    with open(output_file, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=metrics)
+        writer.writeheader()
+        while True:
+            result = await results_queue.get()
+            if result is None: # Sentinel value to stop
+                break
+            writer.writerow(result)
+            results_queue.task_done()
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Run a stress test on an OpenAI-compatible endpoint.")
+    parser.add_argument("--test-config", required=True, help="Path to the stress-test.yaml file.")
+    parser.add_argument("--feature", required=True, help="The feature to test (e.g., 'chatbot').")
+    parser.add_argument("--vendor", required=True, help="The vendor to test (e.g., 'vertexai').")
+    parser.add_argument("--model", required=True, help="The model to test (e.g., 'qwen3-1.5').")
+    parser.add_argument("--mode", required=True, choices=['stress', 'qps'], help="The test mode to run.")
+    args = parser.parse_args()
+
+    # 1. Load and Validate Config
+    base_config_path = 'src/smoke/config.yaml'
+    with open(base_config_path, 'r') as f:
+        config = yaml.safe_load(f)
+
+    with open(args.test_config, 'r') as f:
+        test_config = yaml.safe_load(f)
+    
+    # 2-level deep merge for configs
+    for key, value in test_config.items():
+        if key in config and isinstance(config[key], dict) and isinstance(value, dict):
+            for inner_key, inner_value in value.items():
+                if inner_key in config[key] and isinstance(config[key][inner_key], dict) and isinstance(inner_value, dict):
+                    config[key][inner_key].update(inner_value)
+                else:
+                    config[key][inner_key] = inner_value
+        else:
+            config[key] = value
+
+    if args.vendor not in config['vendors']:
+        raise ValueError(f"Vendor '{args.vendor}' not found in {base_config_path}")
+    vendor_config = config['vendors'][args.vendor]
+
+    if 'model_config' not in vendor_config:
+        raise ValueError(f"Vendor '{args.vendor}' has no 'model_config' section.")
+    
+    if args.model not in vendor_config['model_config']:
+        raise ValueError(f"Model '{args.model}' not found for vendor '{args.vendor}' in {base_config_path}")
+    model_config = vendor_config['model_config'][args.model]
+
+    if args.feature not in config['features']:
+        raise ValueError(f"Feature '{args.feature}' not found in {base_config_path} or {args.test_config}")
+    feature_config = config['features'][args.feature]
+
+    # 2. Initialization
+    run_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = f"benchmark_{run_timestamp}"
+    os.makedirs(run_dir, exist_ok=True)
+    print(f"INFO: Test results will be saved in: {run_dir}")
+
+    api_key = os.getenv(vendor_config['api_key_env'])
+    if not api_key:
+        raise ValueError(f"API key environment variable '{vendor_config['api_key_env']}' not set.")
+
+    client = AsyncOpenAI(api_key=api_key, base_url=vendor_config['api_base'])
+    
+    # 3. Execute Test based on mode
+    if args.mode == 'stress':
+        levels = config['test_config']['concurrency_levels']
+        duration = config['test_config']['stress_duration_seconds']
+        
+        # Load prompts into a list once to avoid exhausting the generator
+        print("INFO: Loading all prompts into memory...")
+        prompts = [p async for p in load_prompts(config['datasets'], feature_config['datasets'])]
+        print(f"INFO: Loaded {len(prompts)} prompts.")
+
+        for level in levels:
+            print(f"\n--- Running STRESS test with concurrency level: {level} for {duration}s ---")
+            
+            # Create a new async generator from the list for each level
+            async def prompt_generator_func():
+                for p in prompts:
+                    yield p
+            
+            prompt_generator = prompt_generator_func()
+            results_queue = asyncio.Queue()
+            semaphore = asyncio.Semaphore(level)
+            
+            output_file = os.path.join(run_dir, f"raw_results_stress_{level}.csv")
+            writer_task = asyncio.create_task(results_writer(results_queue, output_file, config['test_config']['per_request_metrics']))
+
+            run_config = {
+                'vendor': args.vendor, 'model': args.model, 'mode': args.mode, 'level': level,
+                'model_name': args.model,
+                'max_tokens': model_config.get('max_tokens')
+            }
+
+            # Start workers
+            worker_tasks = [
+                asyncio.create_task(worker(i, client, prompt_generator, results_queue, semaphore, config, run_config))
+                for i in range(level)
+            ]
+            
+            # Run for the specified duration
+            await asyncio.sleep(duration)
+
+            # Stop workers
+            for task in worker_tasks:
+                task.cancel()
+            await asyncio.gather(*worker_tasks, return_exceptions=True)
+
+            # Signal writer to stop
+            await results_queue.put(None)
+            await writer_task
+
+            print(f"INFO: Finished stress test for concurrency level {level}. Results saved to {output_file}")
+
+    elif args.mode == 'qps':
+        print("ERROR: QPS mode is not yet implemented.")
+        # Future implementation of QPS logic would go here
+
+    await client.close()
+    print("\n--- Stress test run complete. ---")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This pull request introduces a new benchmarking workflow for evaluating LLM API performance and aggregates results into a comprehensive report. The main changes are the addition of a script for running benchmarks against OpenAI-compatible endpoints, a script for aggregating and summarizing benchmark logs, and a YAML configuration file that standardizes metrics and datasets for stress testing.

### Benchmarking and Reporting Workflow

* Added `benchmark-llm-api-with-dataset.py`, a script to send chat completion requests to an OpenAI-compatible API using prompts from a `.jsonl` dataset, collect detailed per-request statistics (including tokens, durations, and TPS), and output both per-request results and an overall performance report in JSON format.

* Added `src/smoke/aggregate_benchmark_logs.py`, a script to aggregate multiple raw benchmark CSV logs into a single summarized CSV report. This script computes statistics (mean, stdev, percentiles, distributions) for key metrics (TTFT, TPS, E2E duration, token counts), grouped by traffic level, and outputs results in a standardized column order.

* Added `src/smoke/stress_test.py`, a stress test to hit inference server with concurrent clients to determine max QPS that can be handled by the API deployment


### Configuration and Standardization

* Introduced `src/smoke/stress-test.yaml`, a configuration file that defines test parameters (modes, concurrency/QPS levels, duration), lists all per-request metrics to collect, specifies the final aggregated report columns and their order, and catalogs available datasets and vendor-specific overrides. This enables consistent benchmarking and reporting across runs.- update benchmark script